### PR TITLE
Fix Environment GetJanitor return type 

### DIFF
--- a/src/Environment.d.ts
+++ b/src/Environment.d.ts
@@ -12,7 +12,7 @@ export declare namespace Environment {
 	const Reload: () => void;
 	const CreateSnapshot: (name?: string) => void;
 	const SetStoryHolder: (holder?: Instance | undefined) => void;
-	const GetJanitor: <T extends object | void = void>() => Janitor<T>;
+	const GetJanitor: <T extends object | void = void>() => Janitor<T> | undefined;
 
 	const InputListener: InputSignals;
 	const UserInput: UserInputService;


### PR DESCRIPTION
Environment.GetJanitor() returned the type Janitor tho it was Janitor | undefined in reality, which opens opportunities for errors.