### PR TITLE
fix pesde installation not including src/** files

### DIFF
--- a/pesde.toml
+++ b/pesde.toml
@@ -4,7 +4,7 @@ includes = [
     "pesde.toml",
     "README.md",
     "LICENSE.md",
-    "src",
+    "src/**",
 ]
 license = "MIT"
 name = "pepeeltoro41/ui_labs"


### PR DESCRIPTION
the issue:
<img width="288" height="157" alt="Screenshot_487" src="https://github.com/user-attachments/assets/679461c2-947b-475e-a243-78d76d444a75" />

pulling the wally package doesn't have it, it's just more annoying to use do that instead of using the one you've posted on pesde.
:)